### PR TITLE
Fix the "Strange cgit bug"

### DIFF
--- a/cgitrc.repos
+++ b/cgitrc.repos
@@ -1,0 +1,29 @@
+enable-index-owner=0
+
+repo.url=syzygy
+repo.path=/var/git/syzygy/.git
+repo.desc=master repository for staging kdlp.underground.software website infrastructure
+
+repo.url=extenginx
+repo.path=/var/git/syzygy/.git/modules/extenginx
+repo.desc=extensible container for building modular websites with nginx
+
+repo.url=kdlp.underground.software
+repo.path=/var/git/syzygy/.git/modules/kdlp.underground.software
+repo.desc=static website content including images, css, and markdown page sources
+
+repo.url=orbit
+repo.path=/var/git/syzygy/.git/modules/orbit
+repo.desc=python/uwsgi backend for dynamic pages including cgit and authentication
+
+repo.url=tcp_server
+repo.path=/var/git/syzygy/.git/modules/tcp_server
+repo.desc=generic tcp server that dispactches each request to a child process
+
+repo.url=smtp
+repo.path=/var/git/syzygy/.git/modules/smtp
+repo.desc=minimal smtp server with only mail submission and not transfer functionality
+
+repo.url=pop
+repo.path=/var/git/syzygy/.git/modules/pop/
+repo.desc=pop3 server that allows view only access to a shared mailbox

--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -31,13 +31,8 @@ services:
     security_opt:
       - label:disable
     volumes:
-      - ./.git:/var/git/syzygy:ro,z
-      - ./.git/modules/orbit:/var/git/orbit:ro,z
-      - ./.git/modules/tcp_server:/var/git/tcp_server:ro,z
-      - ./.git/modules/pop:/var/git/pop:ro,z
-      - ./.git/modules/smtp:/var/git/smtp:ro,z
-      - ./.git/modules/extenginx:/var/git/extenginx:ro,z
-      - ./.git/modules/kdlp.underground.software:/var/git/kdlp.underground.software:ro,z
+      - .:/var/git/syzygy:ro,z
+      - ./cgitrc.repos:/etc/cgitrc.repos:ro,z
       - ./kdlp.underground.software:/orbit/docs:ro,z
     ports:
       - 9098:9098

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -22,13 +22,8 @@ services:
       dockerfile: Containerfile
       target: orbit
     volumes:
-      - ./.git:/var/git/syzygy:ro,z
-      - ./.git/modules/orbit:/var/git/orbit:ro,z
-      - ./.git/modules/tcp_server:/var/git/tcp_server:ro,z
-      - ./.git/modules/pop:/var/git/pop:ro,z
-      - ./.git/modules/smtp:/var/git/smtp:ro,z
-      - ./.git/modules/extenginx:/var/git/extenginx:ro,z
-      - ./.git/modules/kdlp.underground.software:/var/git/kdlp.underground.software:ro,z
+      - .:/var/git/syzygy:ro,z
+      - ./cgitrc.repos:/etc/cgitrc.repos:ro,z
       - ./kdlp.underground.software:/orbit/docs:ro,z
     ports:
       - 9098:9098


### PR DESCRIPTION
This PR, when combined with the changes in submodules `kdlp.underground.software` and `orbit`, addresses the issue where cgit would not show some repos, and disables the raw/plain view, as cutting and pasting raw text from the cgit output into an html doc has unintended consequences.